### PR TITLE
Update gateone.js

### DIFF
--- a/gateone/static/gateone.js
+++ b/gateone/static/gateone.js
@@ -476,7 +476,7 @@ var go = GateOne.Base.update(GateOne, {
             go.prefs[setting] = queryPrefs[setting];
         }
         // Make our prefix unique to our location
-        go.prefs.prefix += go.location + '_';
+        go.prefs.prefix += go.location.replace(/\./g, 'dot') + '_';
         // Capabilities Notifications
         if (!go.prefs.skipChecks) {
             if (!WebSocket) {


### PR DESCRIPTION
[SOLVED] Fix for location cannot contain dots (ie IP addresses) #733
https://github.com/liftoff/GateOne/issues/733

Link says it all. helps when using gateone with librenms or similar.